### PR TITLE
Fix: auto-start MCP bridge polling (Mac compatibility)

### DIFF
--- a/source/interface/interface.js
+++ b/source/interface/interface.js
@@ -1,3 +1,41 @@
+/* Auto-start bridge polling — runs inside QWebEngine so XMLHttpRequest is available.
+   Polls the MCP bridge at :54321 every 500ms and forwards commands to the Script Engine.
+   No manual bootstrap paste required on any platform. */
+(function startBridge() {
+    var port = 54321;
+    var indicator = null;
+
+    function setStatus(connected) {
+        if (!indicator) return;
+        indicator.style.background = connected ? "#28a745" : "#6c757d";
+        indicator.title = connected ? "MCP Bridge: connected" : "MCP Bridge: waiting...";
+    }
+
+    function poll() {
+        var x = new XMLHttpRequest();
+        x.open("GET", "http://127.0.0.1:" + port + "/next", true);
+        x.timeout = 800;
+        x.onload = function () {
+            setStatus(true);
+            if (x.status === 200 && x.responseText) {
+                $se("runCode", x.responseText);
+            }
+        };
+        x.onerror = x.ontimeout = function () { setStatus(false); };
+        x.send();
+    }
+
+    window.addEventListener("DOMContentLoaded", function () {
+        /* Inject a small status dot next to the Run button */
+        indicator = document.createElement("span");
+        indicator.style.cssText = "display:inline-block;width:10px;height:10px;border-radius:50%;background:#6c757d;margin-left:8px;vertical-align:middle;";
+        indicator.title = "MCP Bridge: waiting...";
+        var runBtn = document.querySelector("button.btn-outline-success");
+        if (runBtn) runBtn.parentNode.insertBefore(indicator, runBtn.nextSibling);
+        setInterval(poll, 500);
+    });
+})();
+
 function copyToClipboard() {
     var currentCode = document.getElementById("codeeditor").value;
     navigator.clipboard.writeText(currentCode);


### PR DESCRIPTION
## Problem

On macOS, the manual bootstrap approach:

```javascript
window.webview.evaluateJavaScriptAsync("setInterval(...)");
```

does not work — `window.webview` is either unavailable or behaves differently in the Mac build of Packet Tracer 9.x. Users who paste the bootstrap and click Run see no polling activity on the MCP bridge, making AI-assisted topology generation impossible on Mac.

## Fix

Add the bridge polling loop **directly to `interface.js`**, which already runs inside QWebEngine (Chromium). QWebEngine has full `XMLHttpRequest` support on all platforms, so this approach works on Mac, Windows, and Linux without any manual user action.

**Changes:**
- `source/interface/interface.js` — IIFE that starts polling `http://127.0.0.1:54321/next` every 500ms on `DOMContentLoaded`
- Adds a small colored status dot next to the Run button (grey = no bridge, green = connected)
- No changes to the Script Engine bootstrap flow — this is purely webview-side

## Result

Opening Builder Code Editor is enough — no bootstrap paste needed on any platform.

## Related

This fix enables the [MCP-Packet-Tracer](https://github.com/Mats2208/MCP-Packet-Tracer) server to work on Mac via Claude Code.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>